### PR TITLE
Fix multi select when tag is select

### DIFF
--- a/selectize-ng.js
+++ b/selectize-ng.js
@@ -18,7 +18,7 @@ angular.module('selectize-ng', [])
         options = angular.extend({
           delimiter: ',',
           persist: true,
-          mode: (element[0].tagName === 'SELECT') ? 'single' : 'multi'
+          mode: (element[0].tagName === 'SELECT') ? ((element[0].hasAttribute("multiple")) ? 'multi' : 'single') : 'multi'
         }, scope.selectize() || {});
 
         // Activate the widget
@@ -99,7 +99,7 @@ angular.module('selectize-ng', [])
             storeInvalidValues(values, parseValues(selectize.getValue()));
           });
         }
-        
+
         function setSelectizeOptions(newOptions) {
           $timeout(function(){
             // prevent digest problems


### PR DESCRIPTION
This fix the problem that when we use `<select multiple>` which is supported by the original selectize, is treated as single select in selectize-ng. This will allow as to make the value as array instead of a string
Link: https://github.com/selectize/selectize.js/blob/master/dist/js/selectize.js#L1261